### PR TITLE
Update platform version to 23.08

### DIFF
--- a/net.werwolv.ImHex.yaml
+++ b/net.werwolv.ImHex.yaml
@@ -1,6 +1,6 @@
 app-id: net.werwolv.ImHex
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: imhex
 rename-desktop-file: imhex.desktop


### PR DESCRIPTION
As most Flatpak applications already moved to org.freedesktop.Platform version 23.08, it would be good time to update it for ImHex too.
Done local build and tested for own use cases, did not notice any major regressions. Although more thorough testing is recommended.