### PR TITLE
Update GLFW to 3.4 & enable Wayland

### DIFF
--- a/net.werwolv.ImHex.yaml
+++ b/net.werwolv.ImHex.yaml
@@ -8,7 +8,8 @@ rename-desktop-file: imhex.desktop
 finish-args:
   - --share=ipc
   - --share=network
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --filesystem=host
   - --device=dri
 
@@ -23,8 +24,8 @@ modules:
       - -DGLFW_BUILD_DOCS=OFF
     sources:
       - type: archive
-        url: https://github.com/glfw/glfw/releases/download/3.3.8/glfw-3.3.8.zip
-        sha256: 4d025083cc4a3dd1f91ab9b9ba4f5807193823e565a5bcf4be202669d9911ea6
+        url: https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip
+        sha256: b5ec004b2712fd08e8861dc271428f048775200a2df719ccf575143ba749a3e9
     cleanup:
       - /include
       - /lib/pkgconfig


### PR DESCRIPTION
[GLFW 3.4](https://github.com/glfw/glfw/releases/tag/3.4) enables Wayland by default.

> It adds runtime platform selection, better support for Wayland, both Wayland and X11 enabled by default, more standard cursor shapes, custom heap allocator support, per-window mouse input passthrough, window title query, a conforming Null platform available everywhere, window hints for initial position, new (harmless) errors informing about missing features, several platform-specific hints, a new native-access function, a hint for selecting ANGLE backend, various other minor features and fixes for issue on all supported platforms.