### PR TITLE
Restrict filesystem permissions

### DIFF
--- a/net.werwolv.ImHex.yaml
+++ b/net.werwolv.ImHex.yaml
@@ -10,7 +10,6 @@ finish-args:
   - --share=network
   - --socket=wayland
   - --socket=fallback-x11
-  - --filesystem=host
   - --device=dri
 
 modules:


### PR DESCRIPTION
This PR removes the permission to give full host filesystem access to ImHex. I've tested this out (opening and saving a few files, downloading stuff from the Content Store and using them, etc.) and I've determined that ImHex doesn't need that permission anymore, considering that it seems like it's using the XDG portal to open files and it downloads stuff to its own app directory