### PR TITLE
Update runtime to org.freedesktop.Platform 25.08

### DIFF
--- a/net.werwolv.ImHex.yaml
+++ b/net.werwolv.ImHex.yaml
@@ -1,6 +1,6 @@
 app-id: net.werwolv.ImHex
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: imhex
 rename-desktop-file: imhex.desktop


### PR DESCRIPTION
I cannot find the reason that `imhex` can't be built on arm64.